### PR TITLE
System Uptime feature

### DIFF
--- a/local_test_shc.sh
+++ b/local_test_shc.sh
@@ -1,4 +1,8 @@
-#!/bin/bash
+# navigate to root directory and activate virtual environment:
+# source venv/bin/activate
+# run the tests:
+# bash local_test_shc.sh
+
 
 # Install dependencies if needed
 pip install -r requirements.txt

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ import argparse
 import logging
 import time
 import os
+from datetime import datetime
 
 def check_cpu():
     return psutil.cpu_percent(interval=1)
@@ -24,6 +25,13 @@ def check_temperature():
     if temperatures:
         return {sensor: temps[0].current for sensor, temps in temperatures.items()}
     return None
+
+def get_system_uptime():
+    boot_time_timestamp = psutil.boot_time()
+    boot_time = datetime.fromtimestamp(boot_time_timestamp)
+    now = datetime.now()
+    uptime = now - boot_time
+    return str(uptime).split('.')[0]  # Remove microseconds
 
 def setup_logging():
     logging.basicConfig(
@@ -52,6 +60,7 @@ def main():
     parser.add_argument('--disk', action='store_true', help="Check disk usage")
     parser.add_argument('--network', action='store_true', help="Check network usage")
     parser.add_argument('--temperature', action='store_true', help="Check system temperature")
+    parser.add_argument('--uptime', action='store_true', help="Check system uptime")
     parser.add_argument('--summary', action='store_true', help="Display summary report & log to file")
     parser.add_argument('--interval', type=int, help="Set interval in seconds for continuous monitoring")
     args = parser.parse_args()
@@ -77,6 +86,8 @@ def main():
                             results[f'Temperature ({sensor})'] = f"{temp}°C"
                     else:
                         results['Temperature'] = "Sensors not available."
+                if args.uptime:
+                    results['System Uptime'] = get_system_uptime()
 
                 display_results(results)
                 log_summary(results)
@@ -100,6 +111,8 @@ def main():
                         results[f'Temperature ({sensor})'] = f"{temp}°C"
                 else:
                     results['Temperature'] = "Sensors not available."
+            if args.uptime:
+                results['System Uptime'] = get_system_uptime()
 
             if args.summary:
                 display_results(results)

--- a/tests/test_shc.py
+++ b/tests/test_shc.py
@@ -1,7 +1,8 @@
 import unittest
 from unittest.mock import patch, MagicMock
+from datetime import datetime, timedelta
 import os
-from main import check_cpu, check_memory, check_disk, check_network, check_temperature, display_results
+from main import check_cpu, check_memory, check_disk, check_network, check_temperature, display_results, get_system_uptime
 
 class TestSystemHealthChecker(unittest.TestCase):
 
@@ -61,6 +62,29 @@ class TestSystemHealthChecker(unittest.TestCase):
             unittest.mock.call('Temperature (sensor1): 55°C')
         ]
         mock_print.assert_has_calls(calls, any_order=False)
+
+
+    @patch('main.psutil.boot_time')
+    def test_get_system_uptime(self, mock_boot_time):
+        # Mock the boot time to a fixed point in the past
+        mock_boot_time.return_value = (datetime.now() - timedelta(hours=5)).timestamp()
+
+        # Calculate expected uptime
+        expected_uptime = timedelta(hours=5)
+
+        # Get actual uptime from the function
+        actual_uptime_str = get_system_uptime()
+
+        # Convert actual uptime string back to a timedelta object for comparison
+        actual_uptime_parts = actual_uptime_str.split(':')
+        actual_uptime = timedelta(
+            hours=int(actual_uptime_parts[0]),
+            minutes=int(actual_uptime_parts[1]),
+            seconds=int(actual_uptime_parts[2])
+        )
+
+        # Check if the actual uptime matches the expected uptime
+        self.assertEqual(expected_uptime, actual_uptime, "Uptime does not match the expected value")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- **Added a new feature for System Uptime:** created a function called `get_system_uptime` to calculate and return the system uptime in `HH:MM:SS` format.
- Updated the `display_results` function to include system uptime in the output when the `--uptime` argument is provided.
- Added a unit test for the `get_system_uptime` function using the `unittest` module. Quite a lengthy test for what feels like a small, simple feature but I want to have testing reliable so there you go.
- Shifted location of `local_test_shc.sh` bash script to root folder and added instructions for running it in comments because I keep forgetting the process of venv before bash lol.